### PR TITLE
catkinize ar_tools (fixes #2)

### DIFF
--- a/ar_pose/CMakeLists.txt
+++ b/ar_pose/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(ar_single
 )
 add_dependencies(ar_single
 	${PROJECT_NAME}_generate_messages_cpp
+	${artoolkit_EXPORTED_TARGETS}
 )
 
 add_executable(ar_multi
@@ -49,4 +50,5 @@ target_link_libraries(ar_multi
 )
 add_dependencies(ar_multi
 	${PROJECT_NAME}_generate_messages_cpp
+	${artoolkit_EXPORTED_TARGETS}
 )

--- a/ar_pose/include/ar_pose/ar_multi.h
+++ b/ar_pose/include/ar_pose/ar_multi.h
@@ -28,11 +28,11 @@
 #include <string.h>
 #include <stdarg.h>
 
-#include <AR/gsub.h>
-#include <AR/video.h>
-#include <AR/param.h>
-#include <AR/ar.h>
-#include <AR/arMulti.h>
+#include <artoolkit/AR/gsub.h>
+#include <artoolkit/AR/video.h>
+#include <artoolkit/AR/param.h>
+#include <artoolkit/AR/ar.h>
+#include <artoolkit/AR/arMulti.h>
 
 #include <ros/ros.h>
 #include <ros/package.h>

--- a/ar_pose/include/ar_pose/ar_single.h
+++ b/ar_pose/include/ar_pose/ar_single.h
@@ -28,9 +28,9 @@
 #include <string.h>
 #include <stdarg.h>
 
-#include <AR/param.h>
-#include <AR/ar.h>
-#include <AR/video.h>
+#include <artoolkit/AR/param.h>
+#include <artoolkit/AR/ar.h>
+#include <artoolkit/AR/video.h>
 
 #include <ros/ros.h>
 #include <ros/package.h>

--- a/ar_pose/src/object.cpp
+++ b/ar_pose/src/object.cpp
@@ -26,7 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <AR/ar.h>
+#include <artoolkit/AR/ar.h>
 #include <ros/ros.h>
 #include <ros/package.h>
 

--- a/artoolkit/CMakeLists.txt
+++ b/artoolkit/CMakeLists.txt
@@ -31,9 +31,11 @@ ExternalProject_Add(ARToolkit
 	# Build
 	BUILD_COMMAND make
 
-	INSTALL_COMMAND cp -r include/AR ${CATKIN_DEVEL_PREFIX}/include/
+	INSTALL_COMMAND mkdir -p ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+		                 ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_LIB_DESTINATION}
+		COMMAND cp -r include/AR ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}/
 		COMMAND cp -r lib/libAR.a lib/libARgsub.a lib/libARgsub_lite.a lib/libARMulti.a lib/libARvideo.a lib/libARgsubUtil.a
-			${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_LIB_DESTINATION}
+			${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_LIB_DESTINATION}/
 )
 
 # add ARgsub library

--- a/artoolkit/CMakeLists.txt
+++ b/artoolkit/CMakeLists.txt
@@ -5,8 +5,12 @@ project(artoolkit)
 
 find_package(catkin REQUIRED)
 
+# add forward declaration for ARToolkit target below
+add_custom_target(ARToolkit_catkin)
+
 catkin_package(
 	LIBRARIES GL glut ARgsub AR ARMulti ARvideo GL glut
+	EXPORTED_TARGETS ARToolkit_catkin
 )
 
 include(ExternalProject)
@@ -38,69 +42,15 @@ ExternalProject_Add(ARToolkit
 			${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_LIB_DESTINATION}/
 )
 
-# add ARgsub library
-add_custom_target(
-  copy_ARgsub ALL
-  COMMAND cmake -E copy ${CMAKE_CURRENT_BINARY_DIR}/ARToolkit-prefix/src/ARToolkit/lib/libARgsub.a ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_LIB_DESTINATION}/libARgsub.a)
+# Resolve forward declaration
+add_dependencies(ARToolkit_catkin ARToolkit)
 
-add_library(ARgsub STATIC)
-set_target_properties(ARgsub PROPERTIES LINKER_LANGUAGE CXX)
-
-add_dependencies(ARgsub copy_ARgsub)
-add_dependencies(copy_ARgsub ARToolkit)
-
-# add AR library
-add_custom_target(
-  copy_AR ALL
-  COMMAND cmake -E copy ${CMAKE_CURRENT_BINARY_DIR}/ARToolkit-prefix/src/ARToolkit/lib/libAR.a ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_LIB_DESTINATION}/libAR.a)
-
-add_library(AR STATIC)
-set_target_properties(AR PROPERTIES LINKER_LANGUAGE CXX)
-
-add_dependencies(AR copy_AR)
-add_dependencies(copy_AR ARToolkit)
-
-# add ARMulti library
-add_custom_target(
-  copy_ARMulti ALL
-  COMMAND cmake -E copy ${CMAKE_CURRENT_BINARY_DIR}/ARToolkit-prefix/src/ARToolkit/lib/libARMulti.a ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_LIB_DESTINATION}/libARMulti.a)
-
-add_library(ARMulti STATIC)
-set_target_properties(ARMulti PROPERTIES LINKER_LANGUAGE CXX)
-
-add_dependencies(ARMulti copy_ARMulti)
-add_dependencies(copy_ARMulti ARToolkit)
-
-# add ARvideo library
-add_custom_target(
-  copy_ARvideo ALL
-  COMMAND cmake -E copy ${CMAKE_CURRENT_BINARY_DIR}/ARToolkit-prefix/src/ARToolkit/lib/libARvideo.a ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_LIB_DESTINATION}/libARvideo.a)
-
-add_library(ARvideo STATIC)
-set_target_properties(ARvideo PROPERTIES LINKER_LANGUAGE CXX)
-
-add_dependencies(ARvideo copy_ARvideo)
-add_dependencies(copy_ARvideo ARToolkit)
-
-# add ARgsubUtil library
-add_custom_target(
-  copy_ARgsubUtil ALL
-  COMMAND cmake -E copy ${CMAKE_CURRENT_BINARY_DIR}/ARToolkit-prefix/src/ARToolkit/lib/libARgsubUtil.a ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_LIB_DESTINATION}/libARgsubUtil.a)
-
-add_library(ARgsubUtil STATIC)
-set_target_properties(ARgsubUtil PROPERTIES LINKER_LANGUAGE CXX)
-
-add_dependencies(ARgsubUtil copy_ARgsubUtil)
-add_dependencies(copy_ARgsubUtil ARToolkit)
-
-
-# add ARgsub_lite library
-add_custom_target(
-  copy_ARgsub_lite ALL
-  COMMAND cmake -E copy ${CMAKE_CURRENT_BINARY_DIR}/ARToolkit-prefix/src/ARToolkit/lib/libARgsub_lite.a ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_LIB_DESTINATION}/libARgsub_lite.a)
-
-add_library(ARgsub_lite STATIC)
-set_target_properties(ARgsub_lite PROPERTIES LINKER_LANGUAGE CXX)
-
-add_dependencies(ARgsub_lite copy_ARgsub_lite)
-add_dependencies(copy_ARgsub_lite ARToolkit)
+# Add cmake targets for each library to make inter-package dependency
+# resolution possible
+foreach(library AR ARgsub ARgsub_lite ARMulti ARvideo ARgsubUtil)
+	add_library(${library} STATIC IMPORTED GLOBAL)
+	set_target_properties(${library} PROPERTIES
+		IMPORTED_LOCATION ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_LIB_DESTINATION}/lib${library}.a
+	)
+	set_target_properties(${library} PROPERTIES LINKER_LANGUAGE CXX)
+endforeach()

--- a/artoolkit/CMakeLists.txt
+++ b/artoolkit/CMakeLists.txt
@@ -22,6 +22,7 @@ ExternalProject_Add(ARToolkit
 	# Patch
 	PATCH_COMMAND patch -p0 < ${CMAKE_CURRENT_SOURCE_DIR}/patch_auto_config
 		COMMAND patch -p0 < ${CMAKE_CURRENT_SOURCE_DIR}/patch_v4l
+		COMMAND patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/use-relative-include-paths-in-headers.patch
 		COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/cleanup.sh
 
 	# Configure (with V4L driver)

--- a/artoolkit/use-relative-include-paths-in-headers.patch
+++ b/artoolkit/use-relative-include-paths-in-headers.patch
@@ -1,0 +1,295 @@
+From f42ea322b2cc3ef699ec4f4a2c6b663ed378764f Mon Sep 17 00:00:00 2001
+From: Max Schwarz <max.schwarz@online.de>
+Date: Thu, 21 Aug 2014 23:56:36 +0200
+Subject: [PATCH] use relative include paths in headers
+
+This enables us to move the headers into the artoolkit folder in the
+devel space, which is consistent with other ROS packages and avoids
+conflicts with system-wide installations of artoolkit.
+---
+ include/AR/ar.h                       |  4 ++--
+ include/AR/arMulti.h                  |  7 ++++---
+ include/AR/gsub.h                     |  6 +++---
+ include/AR/gsubUtil.h                 |  2 +-
+ include/AR/gsub_lite.h                |  7 ++++---
+ include/AR/matrix.h                   |  3 ++-
+ include/AR/param.h                    |  2 +-
+ include/AR/sys/videoGStreamer.h       |  4 ++--
+ include/AR/sys/videoLinux1394Cam.h    |  6 +++---
+ include/AR/sys/videoLinuxDV.h         |  4 ++--
+ include/AR/sys/videoLinuxV4L.h        |  6 +++---
+ include/AR/sys/videoSGI.h             |  4 ++--
+ include/AR/sys/videoWin32DirectShow.h |  4 ++--
+ include/AR/video.h                    | 18 +++++++++---------
+ 14 files changed, 40 insertions(+), 37 deletions(-)
+
+diff --git a/include/AR/ar.h b/include/AR/ar.h
+index 5a24b2b..65ab468 100755
+--- a/include/AR/ar.h
++++ b/include/AR/ar.h
+@@ -44,8 +44,8 @@ extern "C" {
+ #include <stdlib.h>
+ #endif
+ 
+-#include <AR/config.h>
+-#include <AR/param.h>
++#include "config.h"
++#include "param.h"
+ 
+ // ============================================================================
+ //	Public types and defines.
+diff --git a/include/AR/arMulti.h b/include/AR/arMulti.h
+index e5a0308..a976bf2 100755
+--- a/include/AR/arMulti.h
++++ b/include/AR/arMulti.h
+@@ -37,9 +37,10 @@ extern "C" {
+ // ============================================================================
+ 
+ #include <stdio.h>
+-#include <AR/config.h>
+-#include <AR/param.h>
+-#include <AR/ar.h>
++
++#include "config.h"
++#include "param.h"
++#include "ar.h"
+ 
+ // ============================================================================
+ //	Public types and defines.
+diff --git a/include/AR/gsub.h b/include/AR/gsub.h
+index a9702f7..130ef53 100755
+--- a/include/AR/gsub.h
++++ b/include/AR/gsub.h
+@@ -35,9 +35,9 @@ extern "C" {
+ //	Public includes.
+ // ============================================================================
+ 
+-#include <AR/config.h>
+-#include <AR/param.h>
+-#include <AR/ar.h>
++#include "config.h"
++#include "param.h"
++#include "ar.h"
+ 
+ 	// ============================================================================
+ //	Public types and defines.
+diff --git a/include/AR/gsubUtil.h b/include/AR/gsubUtil.h
+index 1812453..4074694 100755
+--- a/include/AR/gsubUtil.h
++++ b/include/AR/gsubUtil.h
+@@ -31,7 +31,7 @@ extern "C" {
+ //	Public includes.
+ // ============================================================================
+ 
+-#include <AR/param.h>
++#include "param.h"
+ 
+ // ============================================================================
+ //	Public types and defines.
+diff --git a/include/AR/gsub_lite.h b/include/AR/gsub_lite.h
+index a2a7899..0bf1aa4 100644
+--- a/include/AR/gsub_lite.h
++++ b/include/AR/gsub_lite.h
+@@ -132,9 +132,10 @@ extern "C" {
+ #  endif
+ #  include <GL/gl.h>
+ #endif
+-#include <AR/config.h>
+-#include <AR/ar.h>		// ARUint8, AR_PIXEL_FORMAT, arDebug, arImage.
+-#include <AR/param.h>	// ARParam, arParamDecompMat(), arParamObserv2Ideal()
++
++#include "config.h"
++#include "ar.h" 		// ARUint8, AR_PIXEL_FORMAT, arDebug, arImage
++#include "param.h"	// ARParam, arParamDecompMat(), arParamObserv2Ideal()
+ 
+ // ============================================================================
+ //	Public types and definitions.
+diff --git a/include/AR/matrix.h b/include/AR/matrix.h
+index abf908f..b5a0d2d 100755
+--- a/include/AR/matrix.h
++++ b/include/AR/matrix.h
+@@ -37,7 +37,8 @@ extern "C" {
+ // ============================================================================
+ 
+ #include <math.h>
+-#include <AR/config.h>
++
++#include "config.h"
+ 
+ // ============================================================================
+ //	Public types and defines.
+diff --git a/include/AR/param.h b/include/AR/param.h
+index 443e811..1bfaf8f 100755
+--- a/include/AR/param.h
++++ b/include/AR/param.h
+@@ -38,7 +38,7 @@ extern "C" {
+ //	Public includes.
+ // ============================================================================
+ 
+-#include <AR/config.h>
++#include "config.h"
+ 
+ // ============================================================================
+ //	Public types and defines.
+diff --git a/include/AR/sys/videoGStreamer.h b/include/AR/sys/videoGStreamer.h
+index 909ed46..84f408c 100644
+--- a/include/AR/sys/videoGStreamer.h
++++ b/include/AR/sys/videoGStreamer.h
+@@ -13,8 +13,8 @@
+ extern "C" {
+ #endif
+ 
+-#include <AR/config.h>
+-#include <AR/ar.h>
++#include "../config.h"
++#include "../ar.h"
+ 
+ typedef struct _AR2VideoParamT AR2VideoParamT;
+ 
+diff --git a/include/AR/sys/videoLinux1394Cam.h b/include/AR/sys/videoLinux1394Cam.h
+index 7052bc1..c762fd4 100755
+--- a/include/AR/sys/videoLinux1394Cam.h
++++ b/include/AR/sys/videoLinux1394Cam.h
+@@ -14,13 +14,13 @@
+ extern "C" {
+ #endif
+ 
+-#include <AR/config.h>
+-#include <AR/ar.h>
++#include "../config.h"
++#include "../ar.h"
+ 
+ #include <stdlib.h>
+ #include <linux/types.h>
+ 
+-#include <AR/v4l-config.h>
++#include "../v4l-config.h"
+ #ifndef HAVE_CAMV4L
+   #include <libv4l1-videodev.h>
+ #else
+diff --git a/include/AR/sys/videoLinuxDV.h b/include/AR/sys/videoLinuxDV.h
+index f48a981..7c14ee0 100755
+--- a/include/AR/sys/videoLinuxDV.h
++++ b/include/AR/sys/videoLinuxDV.h
+@@ -14,8 +14,8 @@
+ extern "C" {
+ #endif
+ 
+-#include <AR/config.h>
+-#include <AR/ar.h>
++#include "../config.h"
++#include "../ar.h"
+ 
+ #include <stdio.h>
+ #include <string.h>
+diff --git a/include/AR/sys/videoLinuxV4L.h b/include/AR/sys/videoLinuxV4L.h
+index 037c75c..4a9bff0 100755
+--- a/include/AR/sys/videoLinuxV4L.h
++++ b/include/AR/sys/videoLinuxV4L.h
+@@ -22,15 +22,15 @@ extern "C" {
+ #include <stdlib.h>
+ #include <linux/types.h>
+ 
+-#include <AR/v4l-config.h>
++#include "../v4l-config.h"
+ #ifndef HAVE_CAMV4L
+   #include <libv4l1-videodev.h>
+ #else
+   #include <linux/videodev.h>
+ #endif
+ 
+-#include <AR/config.h>
+-#include <AR/ar.h>
++#include "../config.h"
++#include "../ar.h"
+ 
+ typedef struct {
+   //device controls
+diff --git a/include/AR/sys/videoSGI.h b/include/AR/sys/videoSGI.h
+index 89f7127..f9543d6 100755
+--- a/include/AR/sys/videoSGI.h
++++ b/include/AR/sys/videoSGI.h
+@@ -15,8 +15,8 @@
+ extern "C" {
+ #endif
+ 
+-#include <AR/config.h>
+-#include <AR/ar.h>
++#include "../config.h"
++#include "../ar.h"
+ 
+ 
+ typedef enum{
+diff --git a/include/AR/sys/videoWin32DirectShow.h b/include/AR/sys/videoWin32DirectShow.h
+index 5b3823b..0b24103 100755
+--- a/include/AR/sys/videoWin32DirectShow.h
++++ b/include/AR/sys/videoWin32DirectShow.h
+@@ -38,8 +38,8 @@
+ #ifndef AR_VIDEO_WIN32_DIRECTSHOW_H
+ #define AR_VIDEO_WIN32_DIRECTSHOW_H
+ 
+-#include <AR/config.h>
+-#include <AR/ar.h>
++#include "../config.h"
++#include "../ar.h"
+ 
+ #include <stdio.h>
+ #include <string.h>
+diff --git a/include/AR/video.h b/include/AR/video.h
+index 57f05dc..7a65186 100755
+--- a/include/AR/video.h
++++ b/include/AR/video.h
+@@ -75,15 +75,15 @@ extern "C" {
+ //	Public includes.
+ // ============================================================================
+ 
+-#include <AR/config.h>
+-#include <AR/ar.h>
++#include "config.h"
++#include "ar.h"
+ 
+ // ============================================================================
+ //	Public types and defines.
+ // ============================================================================
+ 
+ #ifdef _WIN32
+-#  include <AR/sys/videoWin32DirectShow.h>
++#  include "sys/videoWin32DirectShow.h"
+ #  ifdef LIBARVIDEO_EXPORTS
+ #    define AR_DLL_API __declspec(dllexport)
+ #  else
+@@ -99,25 +99,25 @@ extern "C" {
+ 
+ #ifdef __linux
+ #  ifdef AR_INPUT_V4L
+-#    include <AR/sys/videoLinuxV4L.h>
++#    include "sys/videoLinuxV4L.h"
+ #  endif
+ #  ifdef  AR_INPUT_DV
+-#    include <AR/sys/videoLinuxDV.h>
++#    include "sys/videoLinuxDV.h"
+ #  endif
+ #  ifdef  AR_INPUT_1394CAM
+-#    include <AR/sys/videoLinux1394Cam.h>
++#    include "sys/videoLinux1394Cam.h"
+ #  endif
+ #  ifdef  AR_INPUT_GSTREAMER
+-#    include <AR/sys/videoGStreamer.h>
++#    include "sys/videoGStreamer.h"
+ #  endif
+ #endif
+ 
+ #ifdef __sgi
+-#  include <AR/sys/videoSGI.h>
++#  include "sys/videoSGI.h"
+ #endif
+ 
+ #ifdef __APPLE__
+-#  include <AR/sys/videoMacOSX.h>
++#  include "sys/videoMacOSX.h"
+ #endif
+ 
+ // ============================================================================
+-- 
+1.9.1
+


### PR DESCRIPTION
Here is a catkinized version of `ar_tools` (see #2).

`ARToolKit` is downloaded using the ExternalProject CMake module, analog to the `download_unpack_build` capability `rosmake`.

I added myself as maintainer in the `package.xml` files, since one maintainer is mandatory and I couldn't find your email. Please change that.